### PR TITLE
diskq: create shared library from diskq common functionality

### DIFF
--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS += modules/diskq/dqtool
-noinst_LTLIBRARIES += modules/diskq/libsyslog-ng-disk-buffer.la
+lib_LTLIBRARIES += modules/diskq/libsyslog-ng-disk-buffer.la
 module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
 
 modules_diskq_libsyslog_ng_disk_buffer_la_SOURCES = \
@@ -14,8 +14,9 @@ modules_diskq_libsyslog_ng_disk_buffer_la_SOURCES = \
   modules/diskq/qdisk.h \
   modules/diskq/qdisk.c
 
-modules_diskq_libsyslog_ng_disk_buffer_la_CFLAGS	=	\
-	$(AM_CFLAGS) -fPIC
+modules_diskq_libsyslog_ng_disk_buffer_la_CPPFLAGS = \
+  $(AM_CPPFLAGS) \
+  -I$(top_srcdir)/modules/diskq
 modules_diskq_libsyslog_ng_disk_buffer_la_LIBADD	=	\
 	$(MODULE_DEPS_LIBS)
 modules_diskq_libsyslog_ng_disk_buffer_la_DEPENDENCIES	=	\
@@ -27,8 +28,7 @@ modules_diskq_libdisk_buffer_la_SOURCES = \
   modules/diskq/diskq-grammar.y \
   modules/diskq/diskq-parser.c \
   modules/diskq/diskq-parser.h \
-  modules/diskq/diskq-plugin.c \
-  $(modules_diskq_libsyslog_ng_disk_buffer_la_SOURCES)
+  modules/diskq/diskq-plugin.c
 
 BUILT_SOURCES += \
   modules/diskq/diskq-grammar.y \
@@ -37,10 +37,10 @@ BUILT_SOURCES += \
 
 EXTRA_DIST += $(BUILT_SOURCES) modules/diskq/diskq-grammar.ym
 
-modules_diskq_libdisk_buffer_la_CFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq -I$(top_srcdir)/lib -I../../lib
-modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_diskq_libdisk_buffer_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/diskq -I$(top_builddir)/modules/diskq
+modules_diskq_libdisk_buffer_la_LIBADD = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
 modules_diskq_libdisk_buffer_la_LDFLAGS = $(MODULE_LDFLAGS)
-modules_diskq_libdisk_buffer_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)
+modules_diskq_libdisk_buffer_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la
 
 modules_diskq_dqtool_SOURCES = modules/diskq/dqtool.c
 modules_diskq_dqtool_LDADD = \

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,6 +1,6 @@
 DISKQ_TEST_CFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir)/libtest -I$(top_srcdir)/modules/diskq @CFLAGS_NOWARN_POINTER_SIGN@
-DISKQ_TEST_LDFLAGS = -dlpreopen $(top_builddir)/modules/syslogformat/libsyslogformat.la -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la
-DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libdisk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
+DISKQ_TEST_LDFLAGS = -dlpreopen $(top_builddir)/modules/syslogformat/libsyslogformat.la
+DISKQ_TEST_LDADD = $(top_builddir)/libtest/libsyslog-ng-test.a $(top_builddir)/modules/diskq/libsyslog-ng-disk-buffer.la $(top_builddir)/lib/libsyslog-ng.la @TOOL_DEPS_LIBS@ @OPENSSL_LIBS@
 
 modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq \


### PR DESCRIPTION
libsyslog-ng-disk-buffer shared library was created to hold common
functionality. This is used by dqtool and libdisk-buffer module.
